### PR TITLE
Enable build by CI (continuous integration)

### DIFF
--- a/.github/workflows/cmake-multi-platform.yml
+++ b/.github/workflows/cmake-multi-platform.yml
@@ -1,0 +1,70 @@
+name: auto build
+
+on:
+  workflow_dispatch:
+    branches: [ "master", "Essential-v3.1.0" ]
+  push:
+    branches: [ "master", "Essential-v3.1.0" ]
+  pull_request:
+    branches: [ "master", "Essential-v3.1.0" ]
+
+jobs:
+  build:
+    name: ${{ matrix.config.name }}
+    runs-on: ${{ matrix.config.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        config:
+          - {
+              name: "Windows Clang 64 Bit",
+              os: windows-2022,
+              generators: "Ninja",
+              msvc_arch: x64,
+              c_compiler: clang,
+              cpp_compiler: clang++
+            }
+          - {
+              name: "Ubuntu Latest",
+              os: ubuntu-latest,
+              c_compiler: gcc,
+              cpp_compiler: g++,
+            }
+          - {
+              name: "Ubuntu Latest (Clang)",
+              os: ubuntu-latest,
+              c_compiler: clang,
+              cpp_compiler: clang++,
+            }
+          - {
+              name: "Mac OS Latest arm64",
+              os: macos-latest,
+              c_compiler: clang,
+              cpp_compiler: clang++,
+              osx_arch: arm64
+            }
+    env:
+      CMAKE_GENERATOR: "${{ matrix.config.generators }}"
+    steps:
+    - uses: actions/checkout@v4
+    - uses: ilammy/setup-nasm@v1
+    - name: Ubuntu/Mac OS X
+      if: ${{ !contains( matrix.config.os, 'windows' ) }}
+      run: |
+        cmake --fresh -B svt_build -DCMAKE_BUILD_TYPE=Release "-DCMAKE_CXX_COMPILER=${{ matrix.config.cpp_compiler }}" "-DCMAKE_C_COMPILER=${{ matrix.config.c_compiler }}" -DNATIVE=ON -DBUILD_SHARED_LIBS=OFF -DSVT_AV1_LTO=ON -DENABLE_AVX512=ON -DBUILD_DEC=OFF -DREPRODUCIBLE_BUILDS=ON "-DCMAKE_OSX_ARCHITECTURES=${{ matrix.config.osx_arch }}"
+        cmake --build svt_build --config Release
+      shell: bash
+    - name: Windows Clang + Ninja build
+      if: contains( matrix.config.os, 'windows' )
+      run: |
+        set CC=clang
+        set CXX=clang++
+        cmake --fresh -B svt_build -G Ninja -DCMAKE_BUILD_TYPE=Release -DBUILD_SHARED_LIBS=OFF -DSVT_AV1_LTO=ON -DENABLE_AVX512=ON -DCMAKE_C_FLAGS_RELEASE="-ffast-math -O3 -DNDEBUG -march=znver2" -DCMAKE_CXX_FLAGS_RELEASE="-ffast-math -O3 -DNDEBUG -march=znver2" -DREPRODUCIBLE_BUILDS=ON
+        ninja -C svt_build
+      shell: cmd
+    - name: Upload artifacts
+      uses: actions/upload-artifact@v4
+      with:
+        name: ${{ matrix.config.name }}
+        path: Bin/Release/
+        retention-days: 90


### PR DESCRIPTION
For https://github.com/nekotrix/SVT-AV1-Essential/releases/tag/v3.1.0-Essential

```

Linux build: (MD5: Coming Soon)

    AVX2 (x86-64-v3)

macOS build: (MD5: Coming Soon)

    AArch64 (Apple Silicon)

```