### PR TITLE
Add crop feature and fix FFMS2 overriding the user's color choice

### DIFF
--- a/Source/App/app_config.c
+++ b/Source/App/app_config.c
@@ -146,6 +146,8 @@
 #define THREAD_MGMNT "--lp"
 #define PIN_TOKEN "--pin"
 
+#define CROP_TOKEN "--crop"
+
 //double dash
 #define PRESET_TOKEN "--preset"
 #define QP_FILE_NEW_TOKEN "--qpfile"
@@ -696,6 +698,29 @@ static EbErrorType set_injector_frame_rate(EbConfig *cfg, const char *token, con
     return str_to_uint(token, value, &cfg->injector_frame_rate);
 }
 
+static EbErrorType set_crop(EbConfig *cfg, const char *token, const char *value) {
+    (void)token;
+    if (!value) {
+        fprintf(stderr, "Error: --crop requires a value (W:H[:X[:Y]])\n");
+        return EB_ErrorBadParameter;
+    }
+    int cw = 0, ch = 0, cx = 0, cy = 0;
+    int n = sscanf(value, "%d:%d:%d:%d", &cw, &ch, &cx, &cy);
+    if (n < 2 || cw <= 0 || ch <= 0 || cx < 0 || cy < 0) {
+        fprintf(stderr, "Error: Invalid crop value '%s'. Expected W:H[:X[:Y]]\n", value);
+        return EB_ErrorBadParameter;
+    }
+    if ((cw & 1) || (ch & 1) || (cx & 1) || (cy & 1)) {
+        fprintf(stderr, "Error: Crop dimensions and offsets must be even for yuv420p\n");
+        return EB_ErrorBadParameter;
+    }
+    cfg->crop_w = cw;
+    cfg->crop_h = ch;
+    cfg->crop_x = cx;
+    cfg->crop_y = cy;
+    return EB_ErrorNone;
+}
+
 static EbErrorType set_cfg_generic_token(EbConfig *cfg, const char *token, const char *value) {
     if (!strncmp(token, "--", 2))
         token += 2;
@@ -988,8 +1013,11 @@ ConfigDescription fconfig_entry_global_options[] = {
 
     {FORCED_MAX_FRAME_HEIGHT_TOKEN, "Maximum frame height value to force, default is 0 [4-8704]"},
 
+    {CROP_TOKEN,
+     "Crop the input video before encoding. Format: W:H[:X[:Y]] (default X=0, Y=0). Requires FFMS2 input"},
+
     {NUMBER_OF_PICTURES_TOKEN,
-     "Number of frames to encode. If `n` is larger than the input, the encoder will loop back and "
+      "Number of frames to encode. If `n` is larger than the input, the encoder will loop back and "
      "continue encoding, default is 0 [0: until EOF, 1-`(2^63)-1`]"},
 
     {NUMBER_OF_PICTURES_TO_SKIP, "Number of frames to skip. Default is 0 [0: don`t skip, 1-`(2^63)-1`]"},
@@ -1354,6 +1382,7 @@ ConfigEntry config_entry[] = {
     {HEIGHT_LONG_TOKEN, "SourceHeight", set_cfg_generic_token},
     {FORCED_MAX_FRAME_WIDTH_TOKEN, "ForcedMaximumFrameWidth", set_cfg_generic_token},
     {FORCED_MAX_FRAME_HEIGHT_TOKEN, "ForcedMaximumFrameHeight", set_cfg_generic_token},
+    {CROP_TOKEN, "Crop", set_crop},
     // Prediction Structure
     {NUMBER_OF_PICTURES_TOKEN, "FrameToBeEncoded", set_cfg_frames_to_be_encoded},
     {BUFFERED_INPUT_TOKEN, "BufferedInput", set_buffered_input},
@@ -1984,6 +2013,17 @@ static EbErrorType app_verify_config(EbConfig *app_cfg) {
     // Check Input File
     if (app_cfg->input_file == NULL && !app_cfg->use_ffms2) {
         fprintf(app_cfg->error_log_file, "Error: Invalid Input File\n");
+        return_error = EB_ErrorBadParameter;
+    }
+
+    if ((app_cfg->crop_w > 0 || app_cfg->crop_h > 0) && !app_cfg->use_ffms2) {
+        if (app_cfg->input_file_is_fifo)
+            fprintf(app_cfg->error_log_file,
+                "Error: crop only works with container inputs (mp4, mkv, etc). "
+                "Please crop the video stream prior to piping.\n");
+        else
+            fprintf(app_cfg->error_log_file,
+                "Error: crop only works with container inputs (mp4, mkv, etc), not yuv/y4m.\n");
         return_error = EB_ErrorBadParameter;
     }
 

--- a/Source/App/app_config.c
+++ b/Source/App/app_config.c
@@ -704,20 +704,24 @@ static EbErrorType set_crop(EbConfig *cfg, const char *token, const char *value)
         fprintf(stderr, "Error: --crop requires a value (W:H[:X[:Y]])\n");
         return EB_ErrorBadParameter;
     }
-    int cw = 0, ch = 0, cx = 0, cy = 0;
+    int cw = -1, ch = -1, cx = -1, cy = -1;
     int n = sscanf(value, "%d:%d:%d:%d", &cw, &ch, &cx, &cy);
-    if (n < 2 || cw <= 0 || ch <= 0 || cx < 0 || cy < 0) {
+    if (n < 2 || cw <= 0 || ch <= 0) {
         fprintf(stderr, "Error: Invalid crop value '%s'. Expected W:H[:X[:Y]]\n", value);
         return EB_ErrorBadParameter;
     }
-    if ((cw & 1) || (ch & 1) || (cx & 1) || (cy & 1)) {
+    if ((cx < 0 && n >= 3) || (cy < 0 && n >= 4)) {
+        fprintf(stderr, "Error: Crop offsets cannot be negative\n");
+        return EB_ErrorBadParameter;
+    }
+    if ((cw & 1) || (ch & 1) || ((cx & 1) && n >= 3) || ((cy & 1) && n >= 4)) {
         fprintf(stderr, "Error: Crop dimensions and offsets must be even for yuv420p\n");
         return EB_ErrorBadParameter;
     }
     cfg->crop_w = cw;
     cfg->crop_h = ch;
-    cfg->crop_x = cx;
-    cfg->crop_y = cy;
+    cfg->crop_x = (n >= 3) ? cx : -1;
+    cfg->crop_y = (n >= 4) ? cy : -1;
     return EB_ErrorNone;
 }
 
@@ -1614,6 +1618,8 @@ EbConfig *svt_config_ctor(bool color) {
     app_cfg->roi_map_file        = NULL;
     app_cfg->fgs_table_path      = NULL;
     app_cfg->mmap.allow          = true;
+    app_cfg->crop_x              = -1;
+    app_cfg->crop_y              = -1;
 #ifdef LIBDOVI_FOUND
     app_cfg->dovi_rpus = NULL;
 #endif

--- a/Source/App/app_config.h
+++ b/Source/App/app_config.h
@@ -213,6 +213,7 @@ typedef struct EbConfig {
     void *ffms_video_source;
     void *ffms_index;
     int   ffms_track_num;
+    int   crop_x, crop_y, crop_w, crop_h;
 #ifdef CONFIG_WEBM_IO
     bool                     write_webm;        // Enable WebM output
     struct WebmOutputContext webm_ctx;          // WebM context

--- a/Source/App/app_context.c
+++ b/Source/App/app_context.c
@@ -465,6 +465,13 @@ static EbErrorType init_ffms2(EbConfig *app_cfg) {
     int src_height = test_frame->EncodedHeight;
 
     if (app_cfg->crop_w > 0 && app_cfg->crop_h > 0) {
+        if (app_cfg->crop_x == -1) {
+            app_cfg->crop_x = ((src_width - app_cfg->crop_w) / 2) & ~1;
+        }
+        if (app_cfg->crop_y == -1) {
+            app_cfg->crop_y = ((src_height - app_cfg->crop_h) / 2) & ~1;
+        }
+        
         if (app_cfg->crop_w + app_cfg->crop_x > src_width ||
             app_cfg->crop_h + app_cfg->crop_y > src_height) {
             fprintf(stderr, "Error: Crop region %dx%d+%d+%d exceeds source dimensions %dx%d\n",

--- a/Source/App/app_context.c
+++ b/Source/App/app_context.c
@@ -474,9 +474,6 @@ static EbErrorType init_ffms2(EbConfig *app_cfg) {
             FFMS_DestroyIndex(index);
             return EB_ErrorBadParameter;
         }
-        fprintf(stderr, "FFMS2: Cropping %dx%d+%d+%d from %dx%d\n",
-                app_cfg->crop_w, app_cfg->crop_h, app_cfg->crop_x, app_cfg->crop_y,
-                src_width, src_height);
     }
 
     if (!(app_cfg->config.source_width != 0 && (uint32_t)test_frame->EncodedWidth != app_cfg->config.source_width)) {
@@ -500,9 +497,12 @@ static EbErrorType init_ffms2(EbConfig *app_cfg) {
         app_cfg->config.frame_rate_denominator = props->FPSDenominator;
     }
 
-    app_cfg->config.matrix_coefficients = test_frame->ColorSpace;
-    app_cfg->config.color_primaries = test_frame->ColorPrimaries;
-    app_cfg->config.transfer_characteristics = test_frame->TransferCharateristics;
+    if (app_cfg->config.matrix_coefficients == EB_CICP_MC_UNSPECIFIED)
+        app_cfg->config.matrix_coefficients = test_frame->ColorSpace;
+    if (app_cfg->config.color_primaries == EB_CICP_CP_UNSPECIFIED)
+        app_cfg->config.color_primaries = test_frame->ColorPrimaries;
+    if (app_cfg->config.transfer_characteristics == EB_CICP_TC_UNSPECIFIED)
+        app_cfg->config.transfer_characteristics = test_frame->TransferCharateristics;
 
     if (test_frame->ColorRange == 2) {
         app_cfg->config.color_range = EB_CR_FULL_RANGE;

--- a/Source/App/app_context.c
+++ b/Source/App/app_context.c
@@ -461,13 +461,37 @@ static EbErrorType init_ffms2(EbConfig *app_cfg) {
         return EB_ErrorBadParameter;
     }
 
+    int src_width = test_frame->EncodedWidth;
+    int src_height = test_frame->EncodedHeight;
+
+    if (app_cfg->crop_w > 0 && app_cfg->crop_h > 0) {
+        if (app_cfg->crop_w + app_cfg->crop_x > src_width ||
+            app_cfg->crop_h + app_cfg->crop_y > src_height) {
+            fprintf(stderr, "Error: Crop region %dx%d+%d+%d exceeds source dimensions %dx%d\n",
+                    app_cfg->crop_w, app_cfg->crop_h, app_cfg->crop_x, app_cfg->crop_y,
+                    src_width, src_height);
+            FFMS_DestroyVideoSource(video_source);
+            FFMS_DestroyIndex(index);
+            return EB_ErrorBadParameter;
+        }
+        fprintf(stderr, "FFMS2: Cropping %dx%d+%d+%d from %dx%d\n",
+                app_cfg->crop_w, app_cfg->crop_h, app_cfg->crop_x, app_cfg->crop_y,
+                src_width, src_height);
+    }
+
     if (!(app_cfg->config.source_width != 0 && (uint32_t)test_frame->EncodedWidth != app_cfg->config.source_width)) {
-        app_cfg->config.source_width = test_frame->EncodedWidth;
-        app_cfg->input_padded_width = test_frame->EncodedWidth;
+        if (app_cfg->crop_w > 0)
+            app_cfg->config.source_width = app_cfg->crop_w;
+        else
+            app_cfg->config.source_width = test_frame->EncodedWidth;
+        app_cfg->input_padded_width = app_cfg->config.source_width;
     }
     if (!(app_cfg->config.source_height != 0 && (uint32_t)test_frame->EncodedHeight != app_cfg->config.source_height)) {
-        app_cfg->config.source_height = test_frame->EncodedHeight;
-        app_cfg->input_padded_height = test_frame->EncodedHeight;
+        if (app_cfg->crop_h > 0)
+            app_cfg->config.source_height = app_cfg->crop_h;
+        else
+            app_cfg->config.source_height = test_frame->EncodedHeight;
+        app_cfg->input_padded_height = app_cfg->config.source_height;
     }
 
     if (app_cfg->config.frame_rate_numerator != (uint32_t)props->FPSNumerator ||
@@ -532,7 +556,7 @@ static EbErrorType init_ffms2(EbConfig *app_cfg) {
     pixfmts[1] = -1;
 
     if (FFMS_SetOutputFormatV2(video_source, pixfmts,
-                                app_cfg->input_padded_width, app_cfg->config.source_height,
+                                src_width, src_height,
                                 FFMS_RESIZER_BILINEAR, &err_info)) {
         fprintf(stderr, "FFMS2 Error: Failed to set output format to yuv420p10le: %s\n", errmsg);
         FFMS_DestroyVideoSource(video_source);
@@ -555,7 +579,11 @@ static EbErrorType init_ffms2(EbConfig *app_cfg) {
             test_frame->EncodedWidth, test_frame->EncodedHeight, props->NumFrames,
             (double)props->FPSNumerator / props->FPSDenominator);
 
-    if (app_cfg->config.source_width != (uint32_t)test_frame->EncodedWidth ||
+    if (app_cfg->crop_w > 0 && app_cfg->crop_h > 0) {
+        fprintf(stderr, "FFMS2: Cropped from %dx%d to %dx%d\n",
+            test_frame->EncodedWidth, test_frame->EncodedHeight,
+            app_cfg->config.source_width, app_cfg->config.source_height);
+    } else if (app_cfg->config.source_width != (uint32_t)test_frame->EncodedWidth ||
         app_cfg->config.source_height != (uint32_t)test_frame->EncodedHeight) {
         fprintf(stderr, "FFMS2: Scaled from %dx%d to %dx%d\n",
             test_frame->EncodedWidth, test_frame->EncodedHeight,
@@ -609,6 +637,15 @@ static EbErrorType preload_frames_ffms2(EbConfig *app_cfg) {
         const uint8_t *src_y = frame->Data[0];
         const uint8_t *src_u = frame->Data[1];
         const uint8_t *src_v = frame->Data[2];
+
+        if (app_cfg->crop_w > 0 && app_cfg->crop_h > 0) {
+            const int crop_x = app_cfg->crop_x;
+            const int crop_y = app_cfg->crop_y;
+            const int bps = 2;
+            src_y += crop_y * frame->Linesize[0] + crop_x * bps;
+            src_u += (crop_y >> 1) * frame->Linesize[1] + (crop_x >> 1) * bps;
+            src_v += (crop_y >> 1) * frame->Linesize[2] + (crop_x >> 1) * bps;
+        }
 
         for (uint32_t y = 0; y < height; y++) {
             memcpy(dst, src_y, width * 2);

--- a/Source/App/app_process_cmd.c
+++ b/Source/App/app_process_cmd.c
@@ -902,6 +902,15 @@ static void ffms2_read_input_frames(EbConfig *app_cfg, uint8_t is_16bit, EbBuffe
     const uint8_t *src_u = frame->Data[1];
     const uint8_t *src_v = frame->Data[2];
 
+    if (app_cfg->crop_w > 0 && app_cfg->crop_h > 0) {
+        const int crop_x = app_cfg->crop_x;
+        const int crop_y = app_cfg->crop_y;
+        const int bps = 2;
+        src_y += crop_y * frame->Linesize[0] + crop_x * bps;
+        src_u += (crop_y >> 1) * frame->Linesize[1] + (crop_x >> 1) * bps;
+        src_v += (crop_y >> 1) * frame->Linesize[2] + (crop_x >> 1) * bps;
+    }
+
     for (uint32_t y = 0; y < height; y++) {
         memcpy(dst_y, src_y, width * 2);
         dst_y += width * 2;


### PR DESCRIPTION
**New feature:** `--crop` , crops the input video before encoding. Follows FFmpeg's scheme for cropping, requires the encoder to be compiled with FFMS2 and only accepts 'normal' container inputs (mkv, mp4, etc).

**Fixed issue:** Fixed a bug where FFMS2 ignores the user's set colorimetry (`--color-primaries`, `--transfer-characteristics`, etc) and instead sets it's own from the source, sometimes failing and causing the encoder to not receive any color metadata and defaulting back to bt709.